### PR TITLE
Fixed mistake

### DIFF
--- a/tools/GNN_model_weight/utils_newdata.py
+++ b/tools/GNN_model_weight/utils_newdata.py
@@ -1,5 +1,6 @@
 import os
 from typing import Union
+import math
 
 import yaml
 import uproot
@@ -10,6 +11,9 @@ import torch
 import torch.nn.functional as F
 import torch.nn as nn
 from torch_geometric.data import Data
+from scipy.stats import entropy
+
+from ..GNN_model_weight.models import mdn_loss, mdn_loss_new
 
 
 def GetPtWeight(truth_labels, dsid_input, pts, SF, Pythia_or_All=False, signal_config_file="configs/config_signal.yaml"):

--- a/weight_ONLY_TRAINS.py
+++ b/weight_ONLY_TRAINS.py
@@ -50,10 +50,6 @@ def main():
         print("Loading file", file_path)
         dataset += torch.load(file_path)
 
-    for graph in dataset:
-        if hasattr(graph, 'pt'):
-            delattr(graph, 'pt')
-
     # check the number of signal and background jets
     labels = np.array([jet_graph.y for jet_graph in dataset])
     num_signal = (labels==1).sum()
@@ -68,6 +64,10 @@ def main():
     print("Background total weight:", weights_background_total)
     scale_factor = weights_signal_total / weights_background_total
     print("Scale factor:", scale_factor)
+
+    for jet_graph in dataset:
+        if jet_graph.y == 0:
+            jet_graph.weights *= scale_factor
 
     ## define architecture
     batch_size = config['architecture']['batch_size']
@@ -165,7 +165,7 @@ def main():
         writer.writerows(metrics)
 
     if do_combined_training:
-        adv_model_name = config['architecture']['adv_model_name']
+        adv_model_name = config['data']['adv_model_name']
         loss_parameter = config['architecture']['loss_parameter']
         loss_weights = config['architecture']['loss_weights']
         train_loss_clsf = []


### PR DESCRIPTION
Added back the rescaling of weights to balance signal and background which was accidentally removed.

No longer removing pT from graphs before training. The removal was there because the classifier training used to not work if the graphs had a pT attribute; now it works fine.